### PR TITLE
Fix a bug that getRawMinX is called in measureXLabel instead of getMinX

### DIFF
--- a/line-chart-view/src/main/java/org/hogel/android/linechartview/LineChartView.java
+++ b/line-chart-view/src/main/java/org/hogel/android/linechartview/LineChartView.java
@@ -239,7 +239,7 @@ public class LineChartView extends View {
         labelPaint.setTextAlign(Paint.Align.CENTER);
         labelPaint.setTextSize(lineChartStyle.getLabelTextSize());
 
-        long minX = getRawMinX();
+        long minX = getMinX();
         long maxX = getMaxX();
         long xGridUnit = getXGridUnit();
 


### PR DESCRIPTION
It's a tiny mistake.